### PR TITLE
Make the build status on README only show master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CTF-Toolkit
 Toolkit tailored for [CTF](https://ctftime.org/) competitions
 
-[![Build Status](https://travis-ci.org/ztaylor54/CTF-Toolkit.svg)](https://travis-ci.org/ztaylor54/CTF-Toolkit)   [![version](https://badge.fury.io/gh/ztaylor54%2FCTF-Toolkit.svg)](http://badge.fury.io/for/gh/ztaylor54/CTF-Toolkit)  [![Coverage Status](https://coveralls.io/repos/ztaylor54/CTF-Toolkit/badge.svg?branch=master&service=github)](https://coveralls.io/github/ztaylor54/CTF-Toolkit?branch=master)
+[![Build Status](https://travis-ci.org/ztaylor54/CTF-Toolkit.svg?branch=master)](https://travis-ci.org/ztaylor54/CTF-Toolkit)   [![version](https://badge.fury.io/gh/ztaylor54%2FCTF-Toolkit.svg)](http://badge.fury.io/for/gh/ztaylor54/CTF-Toolkit)  [![Coverage Status](https://coveralls.io/repos/ztaylor54/CTF-Toolkit/badge.svg?branch=master&service=github)](https://coveralls.io/github/ztaylor54/CTF-Toolkit?branch=master)
 
 # Repository rules
 


### PR DESCRIPTION
Previously, the build status was showing every branch, and that completely breaks it if a build is failing or erroring on another branch.
